### PR TITLE
feat: update API endpoints for project generation and metadata retrieval

### DIFF
--- a/frontend/src/service.ts
+++ b/frontend/src/service.ts
@@ -108,7 +108,7 @@ export async function generateProject(data: GenerateProjectPayload): Promise<Blo
 
   let response: Response;
   try {
-    response = await fetch(`${API_BASE_URL}/generate`, {
+    response = await fetch(`${API_BASE_URL}/api/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
@@ -140,5 +140,5 @@ export interface MetaData {
 
 /** Fetches supported project metadata from the API. */
 export async function getMetaData(): Promise<MetaData> {
-  return get<MetaData>('/meta');
+  return get<MetaData>('/api/meta');
 }


### PR DESCRIPTION
This pull request updates the API endpoint paths used in the `frontend/src/service.ts` file to include the `/api` prefix. This change ensures that all frontend service calls are correctly routed to the intended backend API endpoints.

**API endpoint updates:**

* Updated the `generateProject` function to use the `/api/generate` endpoint instead of `/generate`.
* Updated the `getMetaData` function to use the `/api/meta` endpoint instead of `/meta`.