### PR TITLE
Feat/UI test cases

### DIFF
--- a/cmd/goini/new.go
+++ b/cmd/goini/new.go
@@ -330,9 +330,9 @@ func promptMissing(cmd *cobra.Command, opts *newOpts) error {
 	// the correct framework list is shown whether projectType came from a flag
 	// or was chosen in Group 1.
 	var (
-		cacheAddons []string
-		dbAddons    []string
-		otherAddons []string
+		cacheAddon string
+		dbAddon    string
+		otherAddon string
 		// Prompt for addons only when neither --addon flag was set AND stdin is
 		// a TTY; in non-TTY / fully-flagged CI runs default to no addons.
 		promptAddons = !cmd.Flags().Changed("addon") && isTTY
@@ -350,22 +350,25 @@ func promptMissing(cmd *cobra.Command, opts *newOpts) error {
 
 	if promptAddons {
 		if cacheOpts := buildSelectOpts(generator.SupportedAddonsMap["cache"]); len(cacheOpts) > 0 {
-			group2 = append(group2, huh.NewMultiSelect[string]().
-				Title("Cache addons").
-				Options(cacheOpts...).
-				Value(&cacheAddons))
+			group2 = append(group2, huh.NewSelect[string]().
+				Title("Cache addon").
+				Description("Select one, or 'none' to skip").
+				Options(append([]huh.Option[string]{huh.NewOption("none", "")}, cacheOpts...)...).
+				Value(&cacheAddon))
 		}
 		if dbOpts := buildSelectOpts(generator.SupportedAddonsMap["database"]); len(dbOpts) > 0 {
-			group2 = append(group2, huh.NewMultiSelect[string]().
-				Title("Database addons").
-				Options(dbOpts...).
-				Value(&dbAddons))
+			group2 = append(group2, huh.NewSelect[string]().
+				Title("Database addon").
+				Description("Select one, or 'none' to skip").
+				Options(append([]huh.Option[string]{huh.NewOption("none", "")}, dbOpts...)...).
+				Value(&dbAddon))
 		}
 		if otherOpts := buildSelectOpts(generator.SupportedAddonsMap["other"]); len(otherOpts) > 0 {
-			group2 = append(group2, huh.NewMultiSelect[string]().
-				Title("Other addons").
-				Options(otherOpts...).
-				Value(&otherAddons))
+			group2 = append(group2, huh.NewSelect[string]().
+				Title("Other addon").
+				Description("Select one, or 'none' to skip").
+				Options(append([]huh.Option[string]{huh.NewOption("none", "")}, otherOpts...)...).
+				Value(&otherAddon))
 		}
 	}
 
@@ -401,14 +404,14 @@ func promptMissing(cmd *cobra.Command, opts *newOpts) error {
 	// Merge interactively collected addons back into opts.addons so that the
 	// downstream parseAddons call handles everything uniformly.
 	if promptAddons {
-		for _, a := range cacheAddons {
-			opts.addons = append(opts.addons, "cache="+a)
+		if cacheAddon != "" {
+			opts.addons = append(opts.addons, "cache="+cacheAddon)
 		}
-		for _, a := range dbAddons {
-			opts.addons = append(opts.addons, "database="+a)
+		if dbAddon != "" {
+			opts.addons = append(opts.addons, "database="+dbAddon)
 		}
-		for _, a := range otherAddons {
-			opts.addons = append(opts.addons, "other="+a)
+		if otherAddon != "" {
+			opts.addons = append(opts.addons, "other="+otherAddon)
 		}
 	}
 
@@ -475,7 +478,10 @@ func parseAddons(raw []string) (map[string][]string, error) {
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return nil, fmt.Errorf("invalid --addon value %q: expected category=value (e.g. --addon cache=redis)", entry)
 		}
-		result[parts[0]] = append(result[parts[0]], parts[1])
+		if _, exists := result[parts[0]]; exists {
+			return nil, fmt.Errorf("addon category %q specified more than once; only one addon per category is allowed", parts[0])
+		}
+		result[parts[0]] = []string{parts[1]}
 	}
 	return result, nil
 }

--- a/cmd/goini/new_test.go
+++ b/cmd/goini/new_test.go
@@ -35,15 +35,25 @@ func makeRunNewCmd() *cobra.Command {
 	return cmd
 }
 
-func TestParseAddons_ValidAndRepeatCategories(t *testing.T) {
-	in := []string{"cache=redis", "database=gorm", "cache=memcached"}
+func TestParseAddons_SingleAddonPerCategory(t *testing.T) {
+	in := []string{"cache=redis", "database=gorm", "other=zap"}
 	out, err := parseAddons(in)
 	require.NoError(t, err)
 
 	require.Contains(t, out, "cache")
 	require.Contains(t, out, "database")
-	assert.ElementsMatch(t, []string{"redis", "memcached"}, out["cache"])
+	require.Contains(t, out, "other")
+	assert.Equal(t, []string{"redis"}, out["cache"])
 	assert.Equal(t, []string{"gorm"}, out["database"])
+	assert.Equal(t, []string{"zap"}, out["other"])
+}
+
+func TestParseAddons_DuplicateCategoryReturnsError(t *testing.T) {
+	in := []string{"cache=redis", "database=gorm", "cache=memcached"}
+	_, err := parseAddons(in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cache")
+	assert.Contains(t, err.Error(), "more than once")
 }
 
 func TestParseAddons_InvalidFormat(t *testing.T) {

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,21 +1,107 @@
-# go-initializer webapp
+# go-initializer frontend
 
-This is the web application for the `go-initializer` project. It provides a user-friendly interface to generate Go project templates based on user-defined configurations.
+This package contains the React frontend for go-initializer. It provides the browser UI for generating Go projects, browsing the built-in documentation, and using the CLI installation guide.
 
-## Features
+## What it includes
 
-- Interactive form to select project options
-- Real-time preview of the generated project structure
-- Downloadable ZIP file of the generated project
-- Responsive design for various screen sizes
+- Landing page for the project
+- Project generator flow at `/generate`
+- Documentation explorer at `/docs`
+- CLI installation and usage guide at `/cli`
+- Light and dark theme support with local persistence
+- API integration for project generation and metadata lookup
 
-## Technologies Used
+## Stack
 
-- React
+- React 18
 - TypeScript
-- Tailwind CSS
-- Vite
+- Vite 8
+- React Router
+- Radix Themes
+- Tailwind CSS 4 and PostCSS
+- Vitest + Testing Library
 
-## Getting Started
+## Prerequisites
 
-### Prerequisites
+- Node.js 18 or newer
+- npm
+- The go-initializer backend running locally if you want to use the generator UI end-to-end
+
+## Local development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Start the dev server:
+
+```bash
+npm start
+```
+
+The frontend runs on port `3000` by default.
+
+## API configuration
+
+The frontend uses `VITE_API_URL` to locate the backend API.
+
+- Default API base URL: `http://localhost:8182`
+- Override it by setting `VITE_API_URL` before starting Vite
+
+Example:
+
+```bash
+VITE_API_URL=http://localhost:8182 npm start
+```
+
+## Available scripts
+
+- `npm start` - start the Vite development server
+- `npm run build` - build the production bundle
+- `npm run preview` - preview the production build locally
+- `npm test` - run the Vitest suite once
+- `npm run test:watch` - run Vitest in watch mode
+- `npm run coverage` - run tests with coverage reporting
+
+## Testing
+
+The frontend test setup uses:
+
+- `vitest` with the `jsdom` environment
+- `@testing-library/react`
+- `@testing-library/jest-dom`
+- coverage via `@vitest/coverage-v8`
+
+Current global coverage thresholds in [vite.config.ts](/Users/adityakumar/code/Projects/go-initializer/frontend/vite.config.ts):
+
+- lines: `80%`
+- branches: `70%`
+
+Run the full suite:
+
+```bash
+npm test
+```
+
+Run coverage:
+
+```bash
+npm run coverage
+```
+
+## Project structure
+
+- `src/App.tsx` - application shell and routing
+- `src/pages` - top-level route pages
+- `src/components` - reusable UI components
+- `src/hooks` - generator state and behavior hooks
+- `src/service.ts` - API client and typed request helpers
+- `src/test/setup.ts` - Vitest setup for the test environment
+
+## Notes
+
+- Unknown routes are redirected to `/`
+- Theme preference is stored in `localStorage`
+- The generator downloads the generated project as a ZIP from the backend

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,14 +22,27 @@
                 "typescript": "^4.9.5"
             },
             "devDependencies": {
+                "@testing-library/jest-dom": "^6.9.1",
+                "@testing-library/react": "^16.3.2",
+                "@testing-library/user-event": "^14.6.1",
                 "@types/react-syntax-highlighter": "^15.5.13",
                 "@vitejs/plugin-react": "^6.0.1",
+                "@vitest/coverage-v8": "^4.1.5",
                 "autoprefixer": "^10.4.21",
+                "jsdom": "^29.0.2",
                 "postcss": "^8.5.6",
                 "postcss-calc": "^10.1.1",
                 "tailwindcss": "^4.1.12",
-                "vite": "^8.0.0"
+                "vite": "^8.0.0",
+                "vitest": "^4.1.5"
             }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+            "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
@@ -43,6 +56,109 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.0"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/@babel/runtime": {
             "version": "7.29.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -50,6 +166,183 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+            "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+            "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+            "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@emnapi/core": {
@@ -81,6 +374,24 @@
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+            "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@floating-ui/core": {
@@ -2024,6 +2335,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@tailwindcss/node": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -2292,6 +2610,96 @@
                 "tailwindcss": "4.2.2"
             }
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+            "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.6.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+            "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=7.21.4"
+            }
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2302,6 +2710,25 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/debug": {
             "version": "4.1.13",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2310,6 +2737,13 @@
             "dependencies": {
                 "@types/ms": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -2429,6 +2863,175 @@
                 }
             }
         },
+        "node_modules/@vitest/coverage-v8": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+            "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^1.0.2",
+                "@vitest/utils": "4.1.5",
+                "ast-v8-to-istanbul": "^1.0.0",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.2.0",
+                "magicast": "^0.5.2",
+                "obug": "^2.1.1",
+                "std-env": "^4.0.0-rc.1",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "4.1.5",
+                "vitest": "4.1.5"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.5",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.5",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/aria-hidden": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2440,6 +3043,45 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+            "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "estree-walker": "^3.0.3",
+                "js-tokens": "^10.0.0"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/autoprefixer": {
             "version": "10.4.27",
@@ -2499,6 +3141,16 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/browserslist": {
@@ -2566,6 +3218,16 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/character-entities": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -2622,6 +3284,34 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/cssesc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2641,6 +3331,20 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2657,6 +3361,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/decode-named-character-reference": {
             "version": "1.3.0",
@@ -2708,6 +3419,14 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.328",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
@@ -2727,6 +3446,26 @@
             "engines": {
                 "node": ">=10.13.0"
             }
+        },
+        "node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -2758,6 +3497,26 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/extend": {
@@ -2849,6 +3608,16 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "license": "ISC"
         },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/hast-util-parse-selector": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -2934,6 +3703,26 @@
             "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
             "license": "CC0-1.0"
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/html-url-attributes": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2942,6 +3731,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/inline-style-parser": {
@@ -3006,6 +3805,52 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/jiti": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -3020,6 +3865,47 @@
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "29.0.2",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+            "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.1.5",
+                "@asamuzakjp/dom-selector": "^7.0.6",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.7",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.24.5",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/lightningcss": {
             "version": "1.32.0",
@@ -3318,6 +4204,27 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3325,6 +4232,34 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+            "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/markdown-table": {
@@ -3606,6 +4541,13 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/micromark": {
             "version": "4.0.2",
@@ -4170,6 +5112,16 @@
             ],
             "license": "MIT"
         },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4201,6 +5153,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
+        },
         "node_modules/parse-entities": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -4224,6 +5187,26 @@
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
             "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT"
+        },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/picocolors": {
@@ -4311,6 +5294,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
         "node_modules/prismjs": {
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -4328,6 +5327,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/radix-ui": {
@@ -4431,6 +5440,14 @@
             "peerDependencies": {
                 "react": "^18.3.1"
             }
+        },
+        "node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-markdown": {
             "version": "10.1.0",
@@ -4580,6 +5597,20 @@
                 "react": ">= 0.14.0"
             }
         },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/refractor": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
@@ -4662,6 +5693,16 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/rolldown": {
             "version": "1.0.0-rc.13",
             "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
@@ -4703,6 +5744,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
         "node_modules/scheduler": {
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -4711,6 +5765,26 @@
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
+        },
+        "node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
@@ -4731,6 +5805,20 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/stringify-entities": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4743,6 +5831,19 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/style-to-js": {
@@ -4763,6 +5864,26 @@
                 "inline-style-parser": "0.2.7"
             }
         },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tailwindcss": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -4782,6 +5903,23 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4797,6 +5935,62 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "7.0.28",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+            "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.28"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.28",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+            "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/trim-lines": {
@@ -4836,6 +6030,16 @@
             },
             "engines": {
                 "node": ">=4.2.0"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/unified": {
@@ -5120,6 +6324,178 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/vitest": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/zwitch": {
             "version": "2.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,10 @@
     "scripts": {
         "start": "vite",
         "build": "vite build",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "coverage": "vitest run --coverage"
     },
     "browserslist": {
         "production": [
@@ -34,12 +37,18 @@
         ]
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.5",
         "autoprefixer": "^10.4.21",
+        "jsdom": "^29.0.2",
         "postcss": "^8.5.6",
         "postcss-calc": "^10.1.1",
         "tailwindcss": "^4.1.12",
-        "vite": "^8.0.0"
+        "vite": "^8.0.0",
+        "vitest": "^4.1.5"
     }
 }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import App from './App';
+
+// ── Heavy child components — render minimal stubs ─────────────────────────────
+
+vi.mock('./pages/HomePage', () => ({ default: () => <div data-testid="home-page">Home</div> }));
+vi.mock('./pages/GeneratorPage', () => ({ default: () => <div data-testid="generator-page">Generator</div> }));
+vi.mock('./pages/CLIPage', () => ({ default: () => <div data-testid="cli-page">CLI</div> }));
+vi.mock('./components/Explore', () => ({ default: ({ onBack }: { onBack: () => void }) => <div data-testid="explore-page"><button onClick={onBack}>back</button></div> }));
+
+// App uses useLocation/useNavigate so it must be wrapped in a Router.
+// We render inside MemoryRouter here instead of BrowserRouter.
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+// ── Routing ───────────────────────────────────────────────────────────────────
+
+describe('App – routing', () => {
+  beforeEach(() => {
+    // Avoid localStorage errors in jsdom
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+    // matchMedia stub
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('renders HomePage at "/"', () => {
+    renderAt('/');
+    expect(screen.getByTestId('home-page')).toBeInTheDocument();
+  });
+
+  it('renders GeneratorPage at "/generate"', () => {
+    renderAt('/generate');
+    expect(screen.getByTestId('generator-page')).toBeInTheDocument();
+  });
+
+  it('renders Explore at "/docs"', () => {
+    renderAt('/docs');
+    expect(screen.getByTestId('explore-page')).toBeInTheDocument();
+  });
+
+  it('renders CLIPage at "/cli"', () => {
+    renderAt('/cli');
+    expect(screen.getByTestId('cli-page')).toBeInTheDocument();
+  });
+
+  it('redirects unknown paths to "/"', () => {
+    renderAt('/does-not-exist');
+    expect(screen.getByTestId('home-page')).toBeInTheDocument();
+  });
+});
+
+// ── Theme toggle ──────────────────────────────────────────────────────────────
+
+describe('App – theme toggle', () => {
+  beforeEach(() => {
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('applies data-theme attribute to document.body', () => {
+    renderAt('/');
+    // Default theme is 'dark' (no localStorage, no prefers-color-scheme)
+    expect(document.body.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('toggles theme when the theme button is clicked', async () => {
+    renderAt('/');
+    expect(document.body.getAttribute('data-theme')).toBe('dark');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /switch to light mode/i }));
+    expect(document.body.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('persists the new theme to localStorage', async () => {
+    // The setItem mock from beforeEach is a no-op. We need to track real calls.
+    // Replace the localStorage instance on window to intercept setItem.
+    const realLS = window.localStorage;
+    const setItemFn = vi.fn();
+    Object.defineProperty(window, 'localStorage', {
+      value: { getItem: vi.fn(() => null), setItem: setItemFn, removeItem: vi.fn(), clear: vi.fn(), length: 0 },
+      configurable: true, writable: true,
+    });
+    renderAt('/');
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /switch to light mode/i }));
+    await act(async () => {});
+    expect(setItemFn).toHaveBeenCalledWith('theme', 'light');
+    Object.defineProperty(window, 'localStorage', { value: realLS, configurable: true, writable: true });
+  });
+});
+
+// ── getInitialTheme ───────────────────────────────────────────────────────────
+// getInitialTheme is a lazy useState initializer — it runs on render inside the
+// component, so mocking localStorage before rendering works correctly.
+
+describe('App – getInitialTheme', () => {
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); document.body.removeAttribute('data-theme'); });
+
+  it('uses "light" when localStorage.theme is "light"', () => {
+    vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn() }));
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+    const realLocalStorage = window.localStorage;
+    const getItemFn = vi.fn((key: string) => key === 'theme' ? 'light' : null);
+    Object.defineProperty(window, 'localStorage', { value: { getItem: getItemFn, setItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn(), length: 0 }, configurable: true, writable: true });
+    renderAt('/');
+    expect(document.body.getAttribute('data-theme')).toBe('light');
+    Object.defineProperty(window, 'localStorage', { value: realLocalStorage, configurable: true, writable: true });
+  });
+
+  it('uses "dark" when localStorage.theme is "dark"', () => {
+    vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn() }));
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => key === 'theme' ? 'dark' : null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+    renderAt('/');
+    // Default when getItem returns null (or 'dark') — result should be 'dark'
+    expect(document.body.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('defaults to "dark" when localStorage is empty and prefers-color-scheme does not match light', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+    vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn() }));
+    renderAt('/');
+    expect(document.body.getAttribute('data-theme')).toBe('dark');
+  });
+});
+
+// ── Header nav links ──────────────────────────────────────────────────────────
+
+describe('App – header navigation', () => {
+  beforeEach(() => {
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {});
+    vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn() }));
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('renders nav links: Generate, Docs, CLI', () => {
+    renderAt('/');
+    expect(screen.getByRole('link', { name: 'Generate' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'CLI' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Explore.test.tsx
+++ b/frontend/src/components/Explore.test.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Explore from './Explore';
+
+// ── Mock docsConfig to keep test data small and predictable ───────────────────
+
+vi.mock('../docsConfig', () => {
+  const docsConfig = [
+    {
+      group: 'Getting Started',
+      pages: [
+        { id: 'introduction', title: 'Introduction', file: '/docs/introduction.md' },
+        { id: 'quick-start', title: 'Quick Start', file: '/docs/quick-start.md' },
+      ],
+    },
+    {
+      group: 'Reference',
+      pages: [
+        { id: 'api-reference', title: 'API Reference', file: '/docs/api-reference.md' },
+      ],
+    },
+  ];
+  return { default: docsConfig };
+});
+
+// ── Mock react-syntax-highlighter (heavy dep, not needed in tests) ────────────
+
+vi.mock('react-syntax-highlighter', () => ({
+  Prism: ({ children }: { children: string }) => <pre>{children}</pre>,
+}));
+vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
+  oneDark: {},
+}));
+
+// ── Helper: stub fetch to return markdown ─────────────────────────────────────
+
+const FIXTURE_MD = `# Introduction\n\n## Overview\n\nWelcome to go-initializer.\n\n## Installation\n\nFoo bar.`;
+
+function stubFetch(text = FIXTURE_MD) {
+  vi.stubGlobal('fetch', vi.fn(() =>
+    Promise.resolve({ ok: true, text: () => Promise.resolve(text) } as Response),
+  ));
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('Explore – rendering', () => {
+  beforeEach(() => stubFetch());
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('renders both sidebar groups', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    const sidebar = container.querySelector('nav[aria-label="Documentation navigation"]')!;
+    await waitFor(() => expect(within(sidebar as HTMLElement).getByText('Getting Started')).toBeInTheDocument());
+    expect(within(sidebar as HTMLElement).getByText('Reference')).toBeInTheDocument();
+  });
+
+  it('renders all sidebar page links', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    const sidebar = container.querySelector('nav[aria-label="Documentation navigation"]')!;
+    await waitFor(() => expect(within(sidebar as HTMLElement).getByText('Introduction')).toBeInTheDocument());
+    expect(within(sidebar as HTMLElement).getByText('Quick Start')).toBeInTheDocument();
+    expect(within(sidebar as HTMLElement).getByText('API Reference')).toBeInTheDocument();
+  });
+
+  it('shows skeleton while content is loading', () => {
+    render(<Explore onBack={vi.fn()} />);
+    expect(document.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+
+  it('renders fetched markdown content after load', async () => {
+    render(<Explore onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/Welcome to go-initializer/)).toBeInTheDocument());
+  });
+});
+
+// ── Page navigation via sidebar ───────────────────────────────────────────────
+
+// Helper to scope queries to the sidebar only (avoids breadcrumb conflicts)
+function getSidebar(container: HTMLElement) {
+  return container.querySelector('nav[aria-label="Documentation navigation"]') as HTMLElement;
+}
+
+describe('Explore – sidebar navigation', () => {
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); vi.clearAllMocks(); });
+
+  it('fetches new page when a different sidebar link is clicked', async () => {
+    stubFetch('# Quick Start\n\nGet going fast.');
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    const sidebar = getSidebar(container);
+    await waitFor(() => expect(within(sidebar).getByText('Quick Start')).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    await user.click(within(sidebar).getByText('Quick Start'));
+
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalledWith('/docs/quick-start.md'));
+  });
+});
+
+// ── Group collapse / expand ───────────────────────────────────────────────────
+
+describe('Explore – group collapse', () => {
+  beforeEach(() => stubFetch());
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('collapses a group when its header is clicked', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    const sidebar = getSidebar(container);
+    await waitFor(() => expect(within(sidebar).getByText('Getting Started')).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    // Click the group header button to collapse
+    await user.click(within(sidebar).getByRole('button', { name: /Getting Started/i }));
+
+    // After collapse, the group pages div should have maxHeight:0
+    await waitFor(() => {
+      const groupPages = sidebar.querySelector('.explore-group:first-child .explore-group-pages') as HTMLElement;
+      expect(groupPages?.style.maxHeight).toBe('0px');
+    });
+  });
+
+  it('expands a collapsed group when its header is clicked again', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    const sidebar = getSidebar(container);
+    await waitFor(() => expect(within(sidebar).getByText('Getting Started')).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    const groupBtn = within(sidebar).getByRole('button', { name: /Getting Started/i });
+    await user.click(groupBtn); // collapse
+    await user.click(groupBtn); // expand
+
+    await waitFor(() => expect(within(sidebar).getByText('Quick Start')).toBeInTheDocument());
+  });
+});
+
+// ── Sidebar search filter ─────────────────────────────────────────────────────
+
+describe('Explore – sidebar search', () => {
+  beforeEach(() => stubFetch());
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('filters pages by query (case-insensitive)', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    const sidebar = getSidebar(container);
+    await waitFor(() => expect(within(sidebar).getByText('Introduction')).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    const searchInput = screen.getByPlaceholderText(/Filter pages/i);
+    await user.type(searchInput, 'api');
+
+    await waitFor(() => {
+      expect(within(sidebar).queryByText('Introduction')).not.toBeInTheDocument();
+      expect(within(sidebar).getByText('API Reference')).toBeInTheDocument();
+    });
+  });
+
+  it('shows all pages when search is cleared', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    const sidebar = getSidebar(container);
+    await waitFor(() => expect(within(sidebar).getByText('Introduction')).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    const searchInput2 = screen.getByPlaceholderText(/Filter pages/i);
+    await user.type(searchInput2, 'api');
+    await user.clear(searchInput2);
+
+    await waitFor(() => {
+      expect(within(sidebar).getByText('Introduction')).toBeInTheDocument();
+      expect(within(sidebar).getByText('Quick Start')).toBeInTheDocument();
+    });
+  });
+});
+
+// ── Prev / Next navigation ────────────────────────────────────────────────────
+
+describe('Explore – prev/next navigation', () => {
+  beforeEach(() => stubFetch());
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('does not render a Prev button on the first page', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    // Wait for content to load
+    await waitFor(() => expect(container.querySelector('.docs-pager-btn--next')).toBeInTheDocument());
+    // "Introduction" is first page, no prev button
+    expect(container.querySelector('.docs-pager-btn--prev')).not.toBeInTheDocument();
+  });
+
+  it('renders Next button on the first page', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    await waitFor(() => expect(container.querySelector('.docs-pager-btn--next')).toBeInTheDocument());
+  });
+
+  it('navigates to next page when Next is clicked', async () => {
+    const { container } = render(<Explore onBack={vi.fn()} />);
+    const user = userEvent.setup();
+    const nextBtn = await waitFor(() => {
+      const btn = container.querySelector('.docs-pager-btn--next') as HTMLElement;
+      expect(btn).toBeInTheDocument();
+      return btn;
+    });
+    await user.click(nextBtn);
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalledWith('/docs/quick-start.md'));
+  });
+});
+
+// ── onBack prop ───────────────────────────────────────────────────────────────
+
+describe('Explore – onBack', () => {
+  beforeEach(() => stubFetch());
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('calls onBack when the back button is clicked', async () => {
+    const onBack = vi.fn();
+    render(<Explore onBack={onBack} />);
+    await waitFor(() => expect(screen.getByText(/Welcome to go-initializer/)).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    // The back button has an aria-label containing "back" or similar
+    const backBtn = screen.getByRole('button', { name: /back/i });
+    await user.click(backBtn);
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── ToC parsing ───────────────────────────────────────────────────────────────
+
+describe('Explore – table of contents', () => {
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('populates ToC from H2 headings in markdown', async () => {
+    stubFetch('# Title\n\n## Section One\n\nContent.\n\n## Section Two\n\nMore content.');
+    render(<Explore onBack={vi.fn()} />);
+    // ToC links are <a> elements with class explore-toc-link
+    await waitFor(() => expect(screen.getAllByText('Section One').length).toBeGreaterThan(0));
+    expect(screen.getAllByText('Section Two').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/GeneratorForm.test.tsx
+++ b/frontend/src/components/GeneratorForm.test.tsx
@@ -1,0 +1,297 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GeneratorForm from './GeneratorForm';
+
+// ── Mock the hook so tests control state deterministically ────────────────────
+
+vi.mock('../hooks/useGeneratorForm', () => ({ useGeneratorForm: vi.fn() }));
+
+import { useGeneratorForm } from '../hooks/useGeneratorForm';
+
+function buildHookState(overrides: Partial<ReturnType<typeof useGeneratorForm>> = {}): ReturnType<typeof useGeneratorForm> {
+  return {
+    dockerSupport: false,
+    setDockerSupport: vi.fn(),
+    selectedAddons: { cache: [], database: [], other: [] },
+    handleAddonChange: vi.fn(),
+    projectType: '',
+    setProjectType: vi.fn(),
+    goVersion: '',
+    setGoVersion: vi.fn(),
+    framework: '',
+    setFramework: vi.fn(),
+    moduleName: '',
+    setModuleName: vi.fn(),
+    name: '',
+    setName: vi.fn(),
+    description: '',
+    setDescription: vi.fn(),
+    touched: { moduleName: false, name: false, description: false, goVersion: false, projectType: false, framework: false },
+    setTouched: vi.fn(),
+    errors: {},
+    setErrors: vi.fn(),
+    goVersionOptions: [
+      { version: '1.23', label: '1.23 (latest stable)' },
+      { version: '1.22', label: '1.22' },
+    ],
+    supportedProjectTypes: [
+      { type: 'microservice', label: 'Microservice' },
+      { type: 'ai-agent', label: 'AI Agent' },
+    ],
+    currentFrameworkOptions: [],
+    addonOptions: {
+      cache: [{ value: 'redis', label: 'Redis' }],
+      database: [{ value: 'gorm', label: 'Gorm' }],
+    },
+    generateError: null,
+    setGenerateError: vi.fn(),
+    generateSuccess: false,
+    setGenerateSuccess: vi.fn(),
+    successCountdown: 5,
+    isGenerating: false,
+    isMac: false,
+    handleGenerate: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('GeneratorForm – rendering', () => {
+  beforeEach(() => vi.mocked(useGeneratorForm).mockReturnValue(buildHookState()));
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders all 6 numbered section labels', () => {
+    render(<GeneratorForm />);
+    ['01', '02', '03', '04', '05', '06'].forEach(n =>
+      expect(screen.getByText(n)).toBeInTheDocument(),
+    );
+  });
+
+  it('renders go version pill buttons', () => {
+    render(<GeneratorForm />);
+    expect(screen.getByText('1.23 (latest stable)')).toBeInTheDocument();
+    expect(screen.getByText('1.22')).toBeInTheDocument();
+  });
+
+  it('renders project type pill buttons', () => {
+    render(<GeneratorForm />);
+    expect(screen.getByText('Microservice')).toBeInTheDocument();
+    expect(screen.getByText('AI Agent')).toBeInTheDocument();
+  });
+
+  it('renders addon chip buttons', () => {
+    render(<GeneratorForm />);
+    expect(screen.getByText('Redis')).toBeInTheDocument();
+    expect(screen.getByText('Gorm')).toBeInTheDocument();
+  });
+
+  it('renders project detail text inputs', () => {
+    render(<GeneratorForm />);
+    expect(screen.getByLabelText(/Module Name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Project Name/i)).toBeInTheDocument();
+  });
+});
+
+// ── aria-pressed on PillButton ────────────────────────────────────────────────
+
+describe('GeneratorForm – PillButton aria-pressed', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('selected version pill has aria-pressed="true"', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ goVersion: '1.23' }));
+    render(<GeneratorForm />);
+    const btn = screen.getByRole('button', { name: '1.23 (latest stable)' });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('unselected version pill has aria-pressed="false"', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ goVersion: '1.23' }));
+    render(<GeneratorForm />);
+    const btn = screen.getByRole('button', { name: '1.22' });
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+});
+
+// ── onInteract callback ───────────────────────────────────────────────────────
+
+describe('GeneratorForm – onInteract callback', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('fires onInteract once on the first pill click', async () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState());
+    const onInteract = vi.fn();
+    render(<GeneratorForm onInteract={onInteract} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '1.22' }));
+    expect(onInteract).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire onInteract a second time on subsequent interaction', async () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState());
+    const onInteract = vi.fn();
+    render(<GeneratorForm onInteract={onInteract} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '1.22' }));
+    await user.click(screen.getByRole('button', { name: '1.23 (latest stable)' }));
+    expect(onInteract).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── ai-agent type banner ──────────────────────────────────────────────────────
+
+describe('GeneratorForm – ai-agent project type', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('shows ai-agent-form-banner when projectType is ai-agent', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ projectType: 'ai-agent' }));
+    const { container } = render(<GeneratorForm />);
+    expect(container.querySelector('.ai-agent-form-banner')).toBeInTheDocument();
+  });
+
+  it('does NOT show ai-agent-form-banner for other project types', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ projectType: 'microservice' }));
+    const { container } = render(<GeneratorForm />);
+    expect(container.querySelector('.ai-agent-form-banner')).not.toBeInTheDocument();
+  });
+
+  it('relabels section 03 to "LLM Provider" when projectType is ai-agent', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ projectType: 'ai-agent' }));
+    render(<GeneratorForm />);
+    expect(screen.getByText('LLM Provider')).toBeInTheDocument();
+  });
+});
+
+// ── Field error display ───────────────────────────────────────────────────────
+
+describe('GeneratorForm – field errors', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('shows field error when errors.goVersion is set and touched', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(
+      buildHookState({
+        errors: { goVersion: 'Go Version is required.' },
+        touched: { moduleName: true, name: true, description: true, goVersion: true, projectType: true, framework: true },
+      }),
+    );
+    render(<GeneratorForm />);
+    expect(screen.getByText('Go Version is required.')).toBeInTheDocument();
+  });
+
+  it('shows field error when errors.projectType is set and touched', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(
+      buildHookState({
+        errors: { projectType: 'Project Type is required.' },
+        touched: { moduleName: true, name: true, description: true, goVersion: true, projectType: true, framework: true },
+      }),
+    );
+    render(<GeneratorForm />);
+    expect(screen.getByText('Project Type is required.')).toBeInTheDocument();
+  });
+
+  it('does NOT show field error when field is not touched', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(
+      buildHookState({
+        errors: { goVersion: 'Go Version is required.' },
+        touched: { moduleName: false, name: false, description: false, goVersion: false, projectType: false, framework: false },
+      }),
+    );
+    render(<GeneratorForm />);
+    expect(screen.queryByText('Go Version is required.')).not.toBeInTheDocument();
+  });
+});
+
+// ── ErrorBanner ───────────────────────────────────────────────────────────────
+
+describe('GeneratorForm – ErrorBanner', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders ErrorBanner with role="alert" when generateError is set', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ generateError: 'API failed' }));
+    render(<GeneratorForm />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('API failed')).toBeInTheDocument();
+  });
+
+  it('calls setGenerateError(null) when dismiss button is clicked', async () => {
+    const setGenerateError = vi.fn();
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ generateError: 'oops', setGenerateError }));
+    render(<GeneratorForm />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /dismiss error/i }));
+    expect(setGenerateError).toHaveBeenCalledWith(null);
+  });
+});
+
+// ── SuccessBanner ─────────────────────────────────────────────────────────────
+
+describe('GeneratorForm – SuccessBanner', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders SuccessBanner with role="status" when generateSuccess is true', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ generateSuccess: true, successCountdown: 3 }));
+    render(<GeneratorForm />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('displays the countdown value', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ generateSuccess: true, successCountdown: 3 }));
+    render(<GeneratorForm />);
+    expect(screen.getByText('3s')).toBeInTheDocument();
+  });
+
+  it('calls setGenerateSuccess(false) when dismiss button clicked', async () => {
+    const setGenerateSuccess = vi.fn();
+    vi.mocked(useGeneratorForm).mockReturnValue(
+      buildHookState({ generateSuccess: true, successCountdown: 5, setGenerateSuccess }),
+    );
+    render(<GeneratorForm />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /dismiss success/i }));
+    expect(setGenerateSuccess).toHaveBeenCalledWith(false);
+  });
+});
+
+// ── Generate button ───────────────────────────────────────────────────────────
+
+describe('GeneratorForm – Generate button', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('is disabled while isGenerating is true', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ isGenerating: true, isMac: false }));
+    render(<GeneratorForm />);
+    // aria-label is always "Generate project (Ctrl+↵)" or "Generate project (⌘↵)"
+    const btn = screen.getByRole('button', { name: /Generate project/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('is enabled when isGenerating is false', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ isGenerating: false, isMac: false }));
+    render(<GeneratorForm />);
+    const btn = screen.getByRole('button', { name: /Generate project/i });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('shows Ctrl+↵ hint on non-Mac', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ isMac: false }));
+    render(<GeneratorForm />);
+    expect(screen.getByText(/Ctrl/)).toBeInTheDocument();
+  });
+
+  it('shows ⌘↵ hint on Mac', () => {
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ isMac: true }));
+    render(<GeneratorForm />);
+    expect(screen.getByText(/⌘/)).toBeInTheDocument();
+  });
+
+  it('calls handleGenerate when button is clicked', async () => {
+    const handleGenerate = vi.fn();
+    vi.mocked(useGeneratorForm).mockReturnValue(buildHookState({ handleGenerate, isMac: false }));
+    render(<GeneratorForm />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Generate project/i }));
+    expect(handleGenerate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/HeroSection.test.tsx
+++ b/frontend/src/components/HeroSection.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import HeroSection from './HeroSection';
+
+// useNavigate needs a router context
+function renderHero() {
+  return render(
+    <MemoryRouter>
+      <HeroSection />
+    </MemoryRouter>,
+  );
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('HeroSection – rendering', () => {
+  it('renders the main headline', () => {
+    renderHero();
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('renders exactly 4 feature cards', () => {
+    const { container } = renderHero();
+    expect(container.querySelectorAll('.hero-feature-card')).toHaveLength(4);
+  });
+
+  it('renders feature card titles', () => {
+    renderHero();
+    expect(screen.getByText('5 Project Types')).toBeInTheDocument();
+    expect(screen.getByText('9 Frameworks')).toBeInTheDocument();
+    expect(screen.getByText('Addons & Docker')).toBeInTheDocument();
+    expect(screen.getByText('CLI + Web UI')).toBeInTheDocument();
+  });
+
+  it('renders AI Spotlight section', () => {
+    const { container } = renderHero();
+    expect(container.querySelector('.ai-spotlight')).toBeInTheDocument();
+  });
+
+  it('renders CTA buttons', () => {
+    renderHero();
+    expect(screen.getByRole('button', { name: /Open Generator/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /View CLI Guide/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Try AI Agent/i })).toBeInTheDocument();
+  });
+});
+
+// ── Navigation ────────────────────────────────────────────────────────────────
+
+describe('HeroSection – navigation', () => {
+  it('"Open Generator →" navigates to /generate', async () => {
+    const { container } = renderHero();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Open Generator/i }));
+    // Navigation is tested indirectly — MemoryRouter updates location
+    // Just verify no errors were thrown and button is still in DOM
+    expect(screen.getByRole('button', { name: /Open Generator/i })).toBeInTheDocument();
+  });
+
+  it('"View CLI Guide →" navigates to /cli', async () => {
+    renderHero();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /View CLI Guide/i }));
+    expect(screen.getByRole('button', { name: /View CLI Guide/i })).toBeInTheDocument();
+  });
+
+  it('"Try AI Agent →" navigates to /generate', async () => {
+    renderHero();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /Try AI Agent/i }));
+    expect(screen.getByRole('button', { name: /Try AI Agent/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TerminalDemo.test.tsx
+++ b/frontend/src/components/TerminalDemo.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TerminalDemo, { TerminalStep } from './TerminalDemo';
+
+// TerminalDemo uses chained setTimeouts (one per state change).
+// We need to flush all timers AND React renders between each timer.
+// This helper repeatedly flushes timers + React in a loop until stable.
+async function drainAnimation() {
+  for (let i = 0; i < 40; i++) {
+    await act(async () => { vi.advanceTimersByTime(50); });
+  }
+}
+const STEPS: TerminalStep[] = [
+  { command: 'go version', output: ['go version go1.23 darwin/arm64'] },
+  { command: 'echo hi', output: [] },
+];
+
+const SINGLE_STEP: TerminalStep[] = [
+  { command: 'ls', output: ['file.go', 'go.mod'] },
+];
+
+describe('TerminalDemo – initial render', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+  it('renders the terminal title', () => {
+    render(<TerminalDemo steps={STEPS} title="test terminal" />);
+    expect(screen.getByText('test terminal')).toBeInTheDocument();
+  });
+
+  it('renders three window-chrome dots', () => {
+    const { container } = render(<TerminalDemo steps={STEPS} />);
+    expect(container.querySelectorAll('.terminal-dot')).toHaveLength(3);
+  });
+
+  it('does not show the replay button initially', () => {
+    render(<TerminalDemo steps={STEPS} />);
+    expect(screen.queryByRole('button', { name: /replay/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('TerminalDemo – typing animation', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+  it('shows a blinking cursor during the typing phase', () => {
+    const { container } = render(<TerminalDemo steps={SINGLE_STEP} />);
+    expect(container.querySelector('.terminal-cursor')).toBeInTheDocument();
+  });
+
+  it('types command characters one-by-one via CHAR_INTERVAL (15ms)', async () => {
+    const { container } = render(<TerminalDemo steps={SINGLE_STEP} />);
+    // Initially no characters typed
+    const promptLine = container.querySelector('.terminal-prompt-line');
+    const initialText = promptLine?.textContent ?? '';
+
+    await act(async () => { vi.advanceTimersByTime(15); });
+    const afterOneChar = promptLine?.textContent ?? '';
+    expect(afterOneChar.length).toBeGreaterThan(initialText.length - 1);
+  });
+
+  it('types full command after enough CHAR_INTERVAL ticks', async () => {
+    const { container } = render(<TerminalDemo steps={SINGLE_STEP} />);
+    const cmd = SINGLE_STEP[0].command; // 'ls' = 2 chars
+    await drainAnimation();
+    const cmdEl = container.querySelector('.terminal-cmd');
+    expect(cmdEl?.textContent).toBe(cmd);
+  });
+});
+
+describe('TerminalDemo – output reveal', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+  it('reveals output lines after the command is typed and POST_CMD_PAUSE (400ms) elapses', async () => {
+    render(<TerminalDemo steps={SINGLE_STEP} />);
+    const cmd = SINGLE_STEP[0].command;
+    // Type full command + pause + first line interval
+    await drainAnimation();
+    expect(screen.getByText('file.go')).toBeInTheDocument();
+  });
+});
+
+describe('TerminalDemo – done phase', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+  it('shows replay button when animation is done', async () => {
+    render(<TerminalDemo steps={SINGLE_STEP} />);
+    const cmd = SINGLE_STEP[0].command;
+    // type + POST_CMD_PAUSE + output lines + POST_STEP_PAUSE
+    const total = 15 * cmd.length + 400 + 120 * SINGLE_STEP[0].output.length + 800 + 100;
+    await drainAnimation();
+    expect(screen.getByText(/Replay/)).toBeInTheDocument();
+  });
+
+  it('hides cursor when animation is done', async () => {
+    const { container } = render(<TerminalDemo steps={SINGLE_STEP} />);
+    const cmd = SINGLE_STEP[0].command;
+    const total = 15 * cmd.length + 400 + 120 * SINGLE_STEP[0].output.length + 800 + 100;
+    await drainAnimation();
+    expect(container.querySelector('.terminal-cursor')).not.toBeInTheDocument();
+  });
+});
+
+describe('TerminalDemo – replay', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+  it('clicking Replay resets to the typing phase (cursor reappears)', async () => {
+    const { container } = render(<TerminalDemo steps={SINGLE_STEP} />);
+    await drainAnimation();
+
+    const replayBtn = screen.getByText(/Replay/);
+    await act(async () => { replayBtn.click(); });
+
+    expect(container.querySelector('.terminal-cursor')).toBeInTheDocument();
+    expect(screen.queryByText(/Replay/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/useGeneratorForm.test.ts
+++ b/frontend/src/hooks/useGeneratorForm.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useGeneratorForm } from './useGeneratorForm';
+
+// ── module-level mocks ────────────────────────────────────────────────────────
+
+vi.mock('../service', () => ({
+  getMetaData: vi.fn(),
+  generateProject: vi.fn(),
+}));
+
+import { getMetaData, generateProject } from '../service';
+
+const mockMeta = {
+  supportedProjectTypes: { microservice: 'Microservice', 'cli-app': 'CLI App' },
+  supportedFrameworks: { microservice: { gin: true, echo: true }, 'cli-app': { cobra: true } },
+  supportedGoVersions: { '1.23': true, '1.22': true },
+  supportedAddons: { cache: { redis: true }, database: { gorm: true }, other: {} },
+};
+
+// ── initial state ─────────────────────────────────────────────────────────────
+
+describe('useGeneratorForm – initial state', () => {
+  beforeEach(() => {
+    vi.mocked(getMetaData).mockResolvedValue(mockMeta);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('initialises all string fields to empty string', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    expect(result.current.projectType).toBe('');
+    expect(result.current.goVersion).toBe('');
+    expect(result.current.framework).toBe('');
+    expect(result.current.moduleName).toBe('');
+    expect(result.current.name).toBe('');
+    expect(result.current.description).toBe('');
+  });
+
+  it('initialises dockerSupport to false and selectedAddons to empty arrays', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    expect(result.current.dockerSupport).toBe(false);
+    expect(result.current.selectedAddons).toEqual({ cache: [], database: [], other: [] });
+  });
+
+  it('initialises errors to empty object', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    expect(result.current.errors).toEqual({});
+  });
+});
+
+// ── getMetaData on mount ──────────────────────────────────────────────────────
+
+describe('useGeneratorForm – metadata on mount', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('populates goVersionOptions after mount', async () => {
+    vi.mocked(getMetaData).mockResolvedValue(mockMeta);
+    const { result } = renderHook(() => useGeneratorForm());
+    await waitFor(() => expect(result.current.goVersionOptions.length).toBeGreaterThan(0));
+    expect(result.current.goVersionOptions[0].label).toMatch(/latest stable/);
+  });
+
+  it('populates supportedProjectTypes after mount', async () => {
+    vi.mocked(getMetaData).mockResolvedValue(mockMeta);
+    const { result } = renderHook(() => useGeneratorForm());
+    await waitFor(() => expect(result.current.supportedProjectTypes.length).toBeGreaterThan(0));
+    expect(result.current.supportedProjectTypes.map(t => t.type)).toContain('microservice');
+  });
+
+  it('does not crash when getMetaData rejects', async () => {
+    vi.mocked(getMetaData).mockRejectedValue(new Error('network error'));
+    const { result } = renderHook(() => useGeneratorForm());
+    // Remains in default state
+    await waitFor(() => expect(result.current.goVersionOptions).toEqual([]));
+  });
+});
+
+// ── handleAddonChange ─────────────────────────────────────────────────────────
+
+describe('useGeneratorForm – handleAddonChange', () => {
+  beforeEach(() => vi.mocked(getMetaData).mockResolvedValue(mockMeta));
+  afterEach(() => vi.clearAllMocks());
+
+  it('adds an addon to the category when not present', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    act(() => result.current.handleAddonChange('cache', 'redis'));
+    expect(result.current.selectedAddons.cache).toContain('redis');
+  });
+
+  it('removes an addon from the category when already present (toggle)', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    act(() => result.current.handleAddonChange('cache', 'redis'));
+    act(() => result.current.handleAddonChange('cache', 'redis'));
+    expect(result.current.selectedAddons.cache).not.toContain('redis');
+  });
+
+  it('does not affect other categories', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    act(() => result.current.handleAddonChange('cache', 'redis'));
+    expect(result.current.selectedAddons.database).toEqual([]);
+  });
+});
+
+// ── validateInput ─────────────────────────────────────────────────────────────
+
+describe('useGeneratorForm – validateInput', () => {
+  beforeEach(() => vi.mocked(getMetaData).mockResolvedValue(mockMeta));
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns false and sets all 6 errors when all fields are empty', () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    let valid: boolean;
+    act(() => { valid = result.current.handleGenerate as unknown as boolean; });
+    // call validateInput indirectly via handleGenerate — it sets errors
+    act(() => result.current.handleGenerate());
+    expect(Object.keys(result.current.errors)).toEqual(
+      expect.arrayContaining(['moduleName', 'name', 'description', 'projectType', 'goVersion', 'framework']),
+    );
+  });
+
+  it('marks all fields as touched on submit attempt', () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    act(() => result.current.handleGenerate());
+    const t = result.current.touched;
+    expect([t.moduleName, t.name, t.description, t.goVersion, t.projectType, t.framework]).toEqual([
+      true, true, true, true, true, true,
+    ]);
+  });
+});
+
+// ── framework reset on projectType change ─────────────────────────────────────
+
+describe('useGeneratorForm – framework reset', () => {
+  beforeEach(() => vi.mocked(getMetaData).mockResolvedValue(mockMeta));
+  afterEach(() => vi.clearAllMocks());
+
+  it('resets framework to "" when projectType changes', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    await waitFor(() => expect(result.current.supportedProjectTypes.length).toBeGreaterThan(0));
+    act(() => result.current.setProjectType('microservice'));
+    act(() => result.current.setFramework('gin'));
+    expect(result.current.framework).toBe('gin');
+    act(() => result.current.setProjectType('cli-app'));
+    await waitFor(() => expect(result.current.framework).toBe(''));
+  });
+});
+
+// ── handleGenerate – validation failure ───────────────────────────────────────
+
+describe('useGeneratorForm – handleGenerate validation failure', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('does NOT call generateProject when fields are empty', () => {
+    vi.mocked(getMetaData).mockResolvedValue(mockMeta);
+    const { result } = renderHook(() => useGeneratorForm());
+    act(() => result.current.handleGenerate());
+    expect(vi.mocked(generateProject)).not.toHaveBeenCalled();
+  });
+});
+
+// ── handleGenerate – happy path ───────────────────────────────────────────────
+
+describe('useGeneratorForm – handleGenerate happy path', () => {
+  let originalCreateElement: typeof document.createElement;
+
+  beforeEach(() => {
+    vi.mocked(getMetaData).mockResolvedValue(mockMeta);
+    vi.mocked(generateProject).mockResolvedValue(new Blob(['zip'], { type: 'application/zip' }));
+    // stub browser download APIs
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:mock'),
+      revokeObjectURL: vi.fn(),
+    });
+    originalCreateElement = document.createElement.bind(document);
+    const mockA = { href: '', download: '', click: vi.fn(), remove: vi.fn(), style: {} };
+    vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') return mockA as unknown as HTMLElement;
+      return originalCreateElement(tag);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('calls generateProject with the correct payload', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    await waitFor(() => expect(result.current.supportedProjectTypes.length).toBeGreaterThan(0));
+
+    act(() => {
+      result.current.setModuleName('github.com/acme/svc');
+      result.current.setName('svc');
+      result.current.setDescription('a service');
+      result.current.setProjectType('microservice');
+      result.current.setGoVersion('1.23');
+    });
+    act(() => { result.current.setFramework('gin'); });
+
+    await act(async () => result.current.handleGenerate());
+
+    expect(vi.mocked(generateProject)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        moduleName: 'github.com/acme/svc',
+        name: 'svc',
+        description: 'a service',
+        projectType: 'microservice',
+        goVersion: '1.23',
+        framework: 'gin',
+      }),
+    );
+  });
+
+  it('sets generateSuccess to true on success', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    await waitFor(() => expect(result.current.supportedProjectTypes.length).toBeGreaterThan(0));
+
+    act(() => {
+      result.current.setModuleName('github.com/acme/svc');
+      result.current.setName('svc');
+      result.current.setDescription('a service');
+      result.current.setProjectType('microservice');
+      result.current.setGoVersion('1.23');
+    });
+    act(() => { result.current.setFramework('gin'); });
+
+    await act(async () => result.current.handleGenerate());
+    expect(result.current.generateSuccess).toBe(true);
+  });
+});
+
+// ── handleGenerate – API error ────────────────────────────────────────────────
+
+describe('useGeneratorForm – handleGenerate API error', () => {
+  beforeEach(() => {
+    vi.mocked(getMetaData).mockResolvedValue(mockMeta);
+    vi.mocked(generateProject).mockRejectedValue(new Error('Server error'));
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('sets generateError to the error message', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    await waitFor(() => expect(result.current.supportedProjectTypes.length).toBeGreaterThan(0));
+
+    act(() => {
+      result.current.setModuleName('github.com/acme/svc');
+      result.current.setName('svc');
+      result.current.setDescription('a service');
+      result.current.setProjectType('microservice');
+      result.current.setGoVersion('1.23');
+    });
+    act(() => { result.current.setFramework('gin'); });
+
+    await act(async () => result.current.handleGenerate());
+    expect(result.current.generateError).toBe('Server error');
+  });
+
+  it('sets isGenerating back to false after error', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    await waitFor(() => expect(result.current.supportedProjectTypes.length).toBeGreaterThan(0));
+
+    act(() => {
+      result.current.setModuleName('github.com/acme/svc');
+      result.current.setName('svc');
+      result.current.setDescription('a service');
+      result.current.setProjectType('microservice');
+      result.current.setGoVersion('1.23');
+    });
+    act(() => { result.current.setFramework('gin'); });
+
+    await act(async () => result.current.handleGenerate());
+    expect(result.current.isGenerating).toBe(false);
+  });
+});
+
+// ── success countdown ─────────────────────────────────────────────────────────
+
+describe('useGeneratorForm – success countdown', () => {
+  let originalCreateElement2: typeof document.createElement;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(getMetaData).mockResolvedValue(mockMeta);
+    vi.mocked(generateProject).mockResolvedValue(new Blob([]));
+    vi.stubGlobal('URL', { createObjectURL: vi.fn(() => 'blob:x'), revokeObjectURL: vi.fn() });
+    vi.spyOn(document.body, 'appendChild').mockImplementation((n) => n);
+    originalCreateElement2 = document.createElement.bind(document);
+    const mockA2 = { href: '', download: '', click: vi.fn(), remove: vi.fn(), style: {} };
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') return mockA2 as unknown as HTMLElement;
+      return originalCreateElement2(tag);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('starts countdown at 5 and decrements to 0 then dismisses success', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+
+    // Trigger success
+    act(() => {
+      result.current.setModuleName('github.com/acme/svc');
+      result.current.setName('svc');
+      result.current.setDescription('desc');
+      result.current.setProjectType('microservice');
+      result.current.setGoVersion('1.23');
+    });
+    act(() => { result.current.setFramework('gin'); });
+
+    await act(async () => result.current.handleGenerate());
+    await act(async () => { await Promise.resolve(); });
+
+    expect(result.current.generateSuccess).toBe(true);
+    expect(result.current.successCountdown).toBe(5);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.successCountdown).toBe(4);
+
+    act(() => vi.advanceTimersByTime(4000));
+    expect(result.current.generateSuccess).toBe(false);
+  });
+});
+
+// ── keyboard shortcut ─────────────────────────────────────────────────────────
+
+describe('useGeneratorForm – keyboard shortcut', () => {
+  let originalCreateElement3: typeof document.createElement;
+  beforeEach(() => {
+    vi.mocked(getMetaData).mockResolvedValue(mockMeta);
+    vi.mocked(generateProject).mockResolvedValue(new Blob([]));
+    vi.stubGlobal('URL', { createObjectURL: vi.fn(() => 'blob:x'), revokeObjectURL: vi.fn() });
+    vi.spyOn(document.body, 'appendChild').mockImplementation((n) => n);
+    originalCreateElement3 = document.createElement.bind(document);
+    const mockA3 = { href: '', download: '', click: vi.fn(), remove: vi.fn(), style: {} };
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') return mockA3 as unknown as HTMLElement;
+      return originalCreateElement3(tag);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('triggers handleGenerate on Ctrl+Enter (non-Mac)', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    await waitFor(() => expect(result.current.supportedProjectTypes.length).toBeGreaterThan(0));
+
+    act(() => {
+      result.current.setModuleName('github.com/acme/svc');
+      result.current.setName('svc');
+      result.current.setDescription('desc');
+      result.current.setProjectType('microservice');
+      result.current.setGoVersion('1.23');
+    });
+    act(() => { result.current.setFramework('gin'); });
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true, bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(generateProject)).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useGeneratorForm.test.ts
+++ b/frontend/src/hooks/useGeneratorForm.test.ts
@@ -95,6 +95,22 @@ describe('useGeneratorForm – handleAddonChange', () => {
     expect(result.current.selectedAddons.cache).not.toContain('redis');
   });
 
+  it('replaces the current selection when a different addon in the same category is chosen', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    act(() => result.current.handleAddonChange('cache', 'redis'));
+    expect(result.current.selectedAddons.cache).toEqual(['redis']);
+    act(() => result.current.handleAddonChange('cache', 'memcached'));
+    expect(result.current.selectedAddons.cache).toEqual(['memcached']);
+    expect(result.current.selectedAddons.cache).not.toContain('redis');
+  });
+
+  it('never accumulates more than one addon per category', async () => {
+    const { result } = renderHook(() => useGeneratorForm());
+    act(() => result.current.handleAddonChange('cache', 'redis'));
+    act(() => result.current.handleAddonChange('cache', 'memcached'));
+    expect(result.current.selectedAddons.cache.length).toBe(1);
+  });
+
   it('does not affect other categories', async () => {
     const { result } = renderHook(() => useGeneratorForm());
     act(() => result.current.handleAddonChange('cache', 'redis'));

--- a/frontend/src/hooks/useGeneratorForm.ts
+++ b/frontend/src/hooks/useGeneratorForm.ts
@@ -80,12 +80,11 @@ export function useGeneratorForm() {
 
   const handleAddonChange = (category: AddonCategory, value: string) => {
     setSelectedAddons(prev => {
-      const alreadySelected = prev[category].includes(value);
+      const currentList = prev[category] || [];
+      const alreadySelected = currentList.includes(value);
       return {
         ...prev,
-        [category]: alreadySelected
-          ? prev[category].filter((v: string) => v !== value)
-          : [...prev[category], value],
+        [category]: alreadySelected ? [] : [value],
       };
     });
   };

--- a/frontend/src/pages/CLIPage.test.tsx
+++ b/frontend/src/pages/CLIPage.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CLIPage from './CLIPage';
+
+// TerminalDemo runs animation timers — stub it to keep tests fast
+vi.mock('../components/TerminalDemo', () => ({
+  default: ({ steps, title }: { steps: unknown[]; title?: string }) => (
+    <div data-testid="terminal-demo" data-steps={steps.length} data-title={title} />
+  ),
+}));
+
+function renderCLI() {
+  return render(
+    <MemoryRouter>
+      <CLIPage />
+    </MemoryRouter>,
+  );
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe('CLIPage – rendering', () => {
+  it('renders the install command', () => {
+    renderCLI();
+    expect(
+      screen.getByText(/go install github\.com\/neo7337\/go-initializer/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the TerminalDemo component', () => {
+    renderCLI();
+    expect(screen.getByTestId('terminal-demo')).toBeInTheDocument();
+  });
+
+  it('renders TerminalDemo with 3 demo steps', () => {
+    renderCLI();
+    expect(screen.getByTestId('terminal-demo')).toHaveAttribute('data-steps', '3');
+  });
+
+  it('renders the flags table with 9 rows', () => {
+    const { container } = renderCLI();
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows).toHaveLength(9);
+  });
+
+  it('renders the copy button', () => {
+    renderCLI();
+    expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
+  });
+});
+
+// ── Copy button ───────────────────────────────────────────────────────────────
+
+describe('CLIPage – copy button', () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('calls clipboard.writeText with the install command', async () => {
+    renderCLI();
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /copy/i })); });
+    expect(writeText).toHaveBeenCalledWith(
+      'go install github.com/neo7337/go-initializer/cmd/goini@latest',
+    );
+  });
+
+  it('shows "Copied!" feedback after click', async () => {
+    renderCLI();
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /copy/i })); });
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.getByText(/Copied/i)).toBeInTheDocument();
+  });
+
+  it('reverts back to "Copy" after 2 s', async () => {
+    renderCLI();
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /copy/i })); });
+    await act(async () => { await Promise.resolve(); });
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.queryByText(/Copied/i)).not.toBeInTheDocument();
+  });
+});
+
+// ── Navigation ────────────────────────────────────────────────────────────────
+
+describe('CLIPage – navigation', () => {
+  it('renders a "Try it in the Web UI" link or button', () => {
+    renderCLI();
+    expect(screen.getByRole('button', { name: /Try it in the Web UI/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/pages.test.tsx
+++ b/frontend/src/pages/pages.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import HomePage from './HomePage';
+import GeneratorPage from './GeneratorPage';
+
+// Stub heavy child components
+vi.mock('../components/HeroSection', () => ({
+  default: () => <div data-testid="hero-section" />,
+}));
+
+vi.mock('../components/GeneratorForm', () => ({
+  default: () => <div data-testid="generator-form" />,
+}));
+
+describe('HomePage', () => {
+  it('renders HeroSection', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('hero-section')).toBeInTheDocument();
+  });
+});
+
+describe('GeneratorPage', () => {
+  it('renders GeneratorForm', () => {
+    render(
+      <MemoryRouter>
+        <GeneratorPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('generator-form')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/service.test.ts
+++ b/frontend/src/service.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ApiError, get, post, generateProject, getMetaData } from './service';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeResponse(status: number, body: unknown, ok = status >= 200 && status < 300): Response {
+  const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+  return {
+    ok,
+    status,
+    statusText: status === 200 ? 'OK' : status === 204 ? 'No Content' : 'Error',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(bodyStr),
+    blob: () => Promise.resolve(new Blob([bodyStr])),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+// ── ApiError ──────────────────────────────────────────────────────────────────
+
+describe('ApiError', () => {
+  it('is an instance of Error', () => {
+    const err = new ApiError(404, 'Not Found', 'resource not found');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('exposes status, statusText, and message', () => {
+    const err = new ApiError(500, 'Internal Server Error', 'something broke');
+    expect(err.status).toBe(500);
+    expect(err.statusText).toBe('Internal Server Error');
+    expect(err.message).toBe('something broke');
+  });
+
+  it('has name "ApiError"', () => {
+    const err = new ApiError(400, 'Bad Request', 'invalid input');
+    expect(err.name).toBe('ApiError');
+  });
+});
+
+// ── request (via get / post) ──────────────────────────────────────────────────
+
+describe('request', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    // stub window.setTimeout/clearTimeout so AbortController tests work in jsdom
+    vi.stubGlobal('window', {
+      ...window,
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns parsed JSON for a 200 response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeResponse(200, { hello: 'world' }));
+    const result = await get<{ hello: string }>('/test');
+    expect(result).toEqual({ hello: 'world' });
+  });
+
+  it('returns undefined for 204 No Content', async () => {
+    const noContent = { ...makeResponse(200, null), ok: true, status: 204 } as unknown as Response;
+    vi.mocked(fetch).mockResolvedValueOnce(noContent);
+    const result = await get<undefined>('/test');
+    expect(result).toBeUndefined();
+  });
+
+  it('throws ApiError for non-2xx responses', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeResponse(404, 'not found', false));
+    await expect(get('/missing')).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it('ApiError carries the correct status from a non-2xx response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeResponse(422, 'validation error', false));
+      let err: unknown;
+      try {
+        await get('/bad');
+      } catch (error) {
+        err = error;
+      }
+      expect(err).toBeInstanceOf(ApiError);
+      if (!(err instanceof ApiError)) {
+        throw err;
+      }
+    expect(err.status).toBe(422);
+  });
+
+  it('throws ApiError(0, Timeout) when the request is aborted', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+      let err: unknown;
+      try {
+        await get('/slow', { timeoutMs: 1 });
+      } catch (error) {
+        err = error;
+      }
+      expect(err).toBeInstanceOf(ApiError);
+      if (!(err instanceof ApiError)) {
+        throw err;
+      }
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(0);
+    expect(err.statusText).toBe('Timeout');
+  });
+
+  it('sends POST with JSON body and Content-Type header', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeResponse(200, { ok: true }));
+    await post('/submit', { name: 'test' });
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect((init as RequestInit).method).toBe('POST');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ name: 'test' });
+    expect(((init as RequestInit).headers as Record<string, string>)['Content-Type']).toBe(
+      'application/json',
+    );
+  });
+});
+
+// ── generateProject ───────────────────────────────────────────────────────────
+
+describe('generateProject', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubGlobal('window', {
+      ...window,
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const payload = {
+    projectType: 'microservice',
+    name: 'my-svc',
+    moduleName: 'github.com/acme/my-svc',
+    description: 'test service',
+    goVersion: '1.23',
+    framework: 'gin',
+    dockerSupport: false,
+    selectedAddons: {},
+  };
+
+  it('POSTs to /api/generate and returns a Blob', async () => {
+    const mockBlob = new Blob(['zip content'], { type: 'application/zip' });
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      blob: () => Promise.resolve(mockBlob),
+      text: () => Promise.resolve(''),
+    } as unknown as Response;
+    vi.mocked(fetch).mockResolvedValueOnce(mockResponse);
+
+    const result = await generateProject(payload);
+    expect(result).toBeInstanceOf(Blob);
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(String(url)).toMatch(/\/api\/generate$/);
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('throws ApiError on non-2xx from /api/generate', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeResponse(500, 'server error', false));
+    await expect(generateProject(payload)).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it('throws ApiError(0, Timeout) when generateProject request times out', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(
+      Object.assign(new Error('aborted'), { name: 'AbortError' }),
+    );
+    const err = await generateProject(payload).catch(e => e);
+    expect(err.status).toBe(0);
+    expect(err.statusText).toBe('Timeout');
+  });
+});
+
+// ── getMetaData ───────────────────────────────────────────────────────────────
+
+describe('getMetaData', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubGlobal('window', {
+      ...window,
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const mockMeta = {
+    supportedProjectTypes: { microservice: 'Microservice' },
+    supportedFrameworks: { microservice: { gin: true } },
+    supportedGoVersions: { '1.23': true },
+    supportedAddons: { cache: { redis: true } },
+  };
+
+  it('GETs /api/meta and returns MetaData', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeResponse(200, mockMeta));
+    const result = await getMetaData();
+    expect(result).toEqual(mockMeta);
+    const [url] = vi.mocked(fetch).mock.calls[0];
+    expect(String(url)).toMatch(/\/api\/meta$/);
+  });
+
+  it('throws ApiError on network failure', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeResponse(503, 'unavailable', false));
+    await expect(getMetaData()).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,13 @@
+import '@testing-library/jest-dom';
+
+// jsdom does not implement IntersectionObserver — provide a no-op stub
+(window as unknown as Record<string, unknown>).IntersectionObserver = class IntersectionObserver {
+  root = null;
+  rootMargin = '';
+  thresholds = [];
+  constructor(_: IntersectionObserverCallback, __?: IntersectionObserverInit) {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] { return []; }
+} as unknown as typeof IntersectionObserver;

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toSupportedFrameworkOptionsMap,
+  toGoVersionOptions,
+  toSupportedProjectTypes,
+  toSupportedAddons,
+  toAddonOptions,
+} from './utils';
+
+// ── toSupportedFrameworkOptionsMap ────────────────────────────────────────────
+
+describe('toSupportedFrameworkOptionsMap', () => {
+  it('maps known keys through the label map', () => {
+    const result = toSupportedFrameworkOptionsMap({
+      microservice: { gin: true, echo: true },
+    });
+    expect(result.microservice).toEqual([
+      { label: 'Gin', value: 'gin' },
+      { label: 'Echo', value: 'echo' },
+    ]);
+  });
+
+  it('applies golly → "golly (recommended)"', () => {
+    const result = toSupportedFrameworkOptionsMap({
+      'simple-project': { golly: true },
+    });
+    expect(result['simple-project'][0].label).toBe('golly (recommended)');
+  });
+
+  it('falls back to the raw key for unknown framework names', () => {
+    const result = toSupportedFrameworkOptionsMap({
+      custom: { myfx: true },
+    });
+    expect(result.custom[0]).toEqual({ label: 'myfx', value: 'myfx' });
+  });
+
+  it('filters out false-valued frameworks', () => {
+    const result = toSupportedFrameworkOptionsMap({
+      microservice: { gin: true, echo: false, fiber: true },
+    });
+    expect(result.microservice.map(o => o.value)).toEqual(['gin', 'fiber']);
+  });
+
+  it('returns an empty array when all frameworks are false', () => {
+    const result = toSupportedFrameworkOptionsMap({
+      microservice: { gin: false },
+    });
+    expect(result.microservice).toEqual([]);
+  });
+
+  it('handles multiple project types independently', () => {
+    const result = toSupportedFrameworkOptionsMap({
+      microservice: { gin: true },
+      'cli-app': { cobra: true },
+    });
+    expect(result.microservice[0].value).toBe('gin');
+    expect(result['cli-app'][0].value).toBe('cobra');
+  });
+});
+
+// ── toGoVersionOptions ────────────────────────────────────────────────────────
+
+describe('toGoVersionOptions', () => {
+  it('sorts versions in descending order', () => {
+    const result = toGoVersionOptions({ '1.21': true, '1.23': true, '1.22': true });
+    expect(result.map(v => v.version)).toEqual(['1.23', '1.22', '1.21']);
+  });
+
+  it('appends "(latest stable)" to the first (highest) version only', () => {
+    const result = toGoVersionOptions({ '1.21': true, '1.23': true });
+    expect(result[0].label).toMatch(/1\.23.*latest stable/);
+    expect(result[1].label).toBe('1.21');
+  });
+
+  it('handles a single version input', () => {
+    const result = toGoVersionOptions({ '1.22.5': true });
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toMatch(/latest stable/);
+  });
+
+  it('handles patch-level version sorting', () => {
+    const result = toGoVersionOptions({ '1.22.1': true, '1.22.10': true, '1.22.2': true });
+    expect(result[0].version).toBe('1.22.10');
+  });
+});
+
+// ── toSupportedProjectTypes ───────────────────────────────────────────────────
+
+describe('toSupportedProjectTypes', () => {
+  it('converts a record to {type, label}[] array', () => {
+    const result = toSupportedProjectTypes({ microservice: 'Microservice', 'cli-app': 'CLI App' });
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { type: 'microservice', label: 'Microservice' },
+        { type: 'cli-app', label: 'CLI App' },
+      ]),
+    );
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(toSupportedProjectTypes({})).toEqual([]);
+  });
+});
+
+// ── toSupportedAddons ─────────────────────────────────────────────────────────
+
+describe('toSupportedAddons', () => {
+  it('returns only addons where the value is true', () => {
+    const result = toSupportedAddons({
+      cache: { redis: true, memcached: false },
+      database: { gorm: true },
+    });
+    expect(result.cache).toEqual(['redis']);
+    expect(result.database).toEqual(['gorm']);
+  });
+
+  it('returns empty arrays when all entries are false', () => {
+    const result = toSupportedAddons({ cache: { redis: false } });
+    expect(result.cache).toEqual([]);
+  });
+
+  it('handles an empty category map', () => {
+    const result = toSupportedAddons({ cache: {} });
+    expect(result.cache).toEqual([]);
+  });
+});
+
+// ── toAddonOptions ────────────────────────────────────────────────────────────
+
+describe('toAddonOptions', () => {
+  it('applies the label map for known keys', () => {
+    const result = toAddonOptions({ cache: { redis: true } });
+    expect(result.cache[0]).toEqual({ value: 'redis', label: 'Redis' });
+  });
+
+  it('applies label map: memcached, gorm, ent, zap, logrus, cobra, urfave, kingpin', () => {
+    const input = { other: { zap: true, logrus: true, gorm: true } };
+    const result = toAddonOptions(input);
+    const labels = result.other.map(o => o.label);
+    expect(labels).toContain('Zap');
+    expect(labels).toContain('Logrus');
+    expect(labels).toContain('Gorm');
+  });
+
+  it('falls back to the raw key for unknown addon names', () => {
+    const result = toAddonOptions({ other: { myaddon: true } });
+    expect(result.other[0]).toEqual({ value: 'myaddon', label: 'myaddon' });
+  });
+
+  it('filters out false entries', () => {
+    const result = toAddonOptions({ cache: { redis: true, memcached: false } });
+    expect(result.cache.map(o => o.value)).toEqual(['redis']);
+  });
+
+  it('returns empty array for a category with no true entries', () => {
+    const result = toAddonOptions({ cache: { redis: false } });
+    expect(result.cache).toEqual([]);
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,4 +6,16 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      thresholds: {
+        lines: 80,
+        branches: 70,
+      },
+    },
+  },
 });

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -50,6 +51,16 @@ func GenerateHandler(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
+	for category, values := range request.Addons {
+		if len(values) > 1 {
+			log.Printf("[WARN] Multiple addons for category %q: %v", category, values)
+			ctx.JSON(http.StatusBadRequest, gin.H{
+				"error": fmt.Sprintf("addon category %q allows at most one selection", category),
+			})
+			return
+		}
+	}
+
 	log.Printf("[INFO] Received request: projectType=%s name=%s moduleName=%s goVersion=%s framework=%s",
 		request.ProjectType, request.Name, request.ModuleName, request.GoVersion, request.Framework)
 

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -367,3 +367,57 @@ func TestGenerateHandler_PathTraversalName_Returns400(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Contains(t, resp, "error")
 }
+
+// ─── Addon cardinality ────────────────────────────────────────────────────────
+
+func TestGenerateHandler_MultipleAddonsPerCategory_Returns400(t *testing.T) {
+	r := newTestRouter()
+
+	payload := map[string]interface{}{
+		"projectType": "microservice",
+		"goVersion":   "1.24.6",
+		"framework":   "gin",
+		"moduleName":  "github.com/acme/x",
+		"name":        "x",
+		"selectedAddons": map[string][]string{
+			"cache": {"redis", "memcached"},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/generate", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Contains(t, resp, "error")
+	assert.Contains(t, resp["error"], "cache")
+}
+
+func TestGenerateHandler_SingleAddonPerCategory_Returns200(t *testing.T) {
+	r := newTestRouter()
+
+	payload := map[string]interface{}{
+		"projectType": "microservice",
+		"goVersion":   "1.24.6",
+		"framework":   "gin",
+		"moduleName":  "github.com/acme/x",
+		"name":        "x",
+		"selectedAddons": map[string][]string{
+			"cache":    {"redis"},
+			"database": {"gorm"},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/generate", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/zip", w.Header().Get("Content-Type"))
+}


### PR DESCRIPTION
This pull request introduces several improvements to both the backend CLI and the frontend of the `go-initializer` project. The most notable backend change is enforcing that only one addon per category can be selected, both in the interactive prompt and via the CLI flag. On the frontend, the update adds comprehensive documentation, testing infrastructure, and a new test suite for the main application shell.

**Backend: Enforce single addon per category**

* Changed the interactive prompt in `cmd/goini/new.go` to only allow selecting one addon per category (cache, database, other) instead of multiple, updating both the prompt logic and how selections are merged into options. [[1]](diffhunk://#diff-255016f7a2cd2835439fd6c571930d0246589d799e74b9744aaf2b272fa9a6d5L333-R335) [[2]](diffhunk://#diff-255016f7a2cd2835439fd6c571930d0246589d799e74b9744aaf2b272fa9a6d5L353-R371) [[3]](diffhunk://#diff-255016f7a2cd2835439fd6c571930d0246589d799e74b9744aaf2b272fa9a6d5L404-R414)
* Updated `parseAddons` to return an error if the same addon category is specified more than once, enforcing the one-addon-per-category rule.
* Adjusted and expanded tests to validate single-addon enforcement and error on duplicates.

**Frontend: Documentation and testing infrastructure**

* Rewrote and expanded `frontend/README.md` to provide clear instructions on features, stack, development, API configuration, scripts, testing, and project structure.
* Added new scripts to `frontend/package.json` for running and watching tests, and for coverage reporting; included necessary dev dependencies for React Testing Library, Vitest, and jsdom. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L22-R25) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R40-R52)
* Introduced a comprehensive test suite for `src/App.tsx`, covering routing, theme toggling, theme persistence, and header navigation, using Vitest and React Testing Library.